### PR TITLE
Remove kafka topic dependency from field data to hook level 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,9 @@ logger := logrus.New()
 logger.Hooks.Add(hook)
 ```
 
-### Add topics
+### Topic
 
-```Go
-l := logger.WithField("topics", []string{"topic_1", "topic_2", "topic_3"})
-```
-
-The field name must be ***topics***.
-
-If only one topic needed, then
-
-```Go
-l := logger.WithField("topics", []string{"topic_1"})
-```
+For only one topic pass the Kafka topic name as the Id.
 
 ### Send messages to logger
 

--- a/examples/kh_example.go
+++ b/examples/kh_example.go
@@ -1,15 +1,16 @@
 package main
 
 import (
-	lkh "github.com/gfremex/logrus-kafka-hook"
-	"github.com/Sirupsen/logrus"
 	"time"
+
+	"github.com/Sirupsen/logrus"
+	lkh "github.com/gfremex/logrus-kafka-hook"
 )
 
 func main() {
 	// Create a new KafkaHook
 	hook, err := lkh.NewKafkaHook(
-		"kh",
+		"topic_1",
 		[]logrus.Level{logrus.InfoLevel, logrus.WarnLevel, logrus.ErrorLevel},
 		&logrus.JSONFormatter{},
 		[]string{"192.168.60.5:9092", "192.168.60.6:9092", "192.168.60.7:9092"},
@@ -24,9 +25,6 @@ func main() {
 
 	// Add hook to logger
 	logger.Hooks.Add(hook)
-
-	// Add topics
-	l := logger.WithField("topics", []string{"topic_1", "topic_2", "topic_3"})
 
 	// Send message to logger
 	l.Debug("This must not be logged")


### PR DESCRIPTION
In a multi-module app using logrus fields are dependent on certain modules and keep changing. To maintain the topics with existing fields coming from other modules is but difficult. 

Better option is handling the topics on the hook level. To achieve it we can use 
* Hook id as the topic name, in case of single topic 
* Introduce a new topic param in case of multi-topic  
I only need single topic to implemented the first point. I will also implement the second one,  If  needed
